### PR TITLE
Add support for Oblivion Remastered on MO2Notes.cpp

### DIFF
--- a/src/plugin/MO2Notes.cpp
+++ b/src/plugin/MO2Notes.cpp
@@ -21,7 +21,7 @@ QString MO2Notes::name() const { return NAME; }
 
 std::vector<std::shared_ptr<const MOBase::IPluginRequirement> > MO2Notes::requirements() const
 {
-    return { Requirements::gameDependency({ u"Oblivion"_s, u"Fallout 3"_s, u"New Vegas"_s, u"Skyrim"_s, u"Enderal"_s,
+    return { Requirements::gameDependency({ u"Oblivion"_s, u"Oblivion Remastered"_s, u"Fallout 3"_s, u"New Vegas"_s, u"Skyrim"_s, u"Enderal"_s,
                                             u"Fallout 4"_s, u"Skyrim Special Edition"_s, u"Enderal Special Edition"_s,
                                             u"Skyrim VR"_s, u"Fallout 4 VR"_s,
                                             u"Starfield"_s }) };


### PR DESCRIPTION
Hi, as mentioned in issue #1 , MO2 already supports Oblivion Remastered on 2.5.3 dev and beta builds (available in their discord server). Is there anything else needed (or any other reason) for MO2 to be able to use your plugin with the game, or just this change?

Thanks again for this plugin! :smiley: 