### PR TITLE
Add support for Oblivion Remastered on MO2Notes.cpp (Correct order)

### DIFF
--- a/src/plugin/MO2Notes.cpp
+++ b/src/plugin/MO2Notes.cpp
@@ -24,7 +24,7 @@ std::vector<std::shared_ptr<const MOBase::IPluginRequirement> > MO2Notes::requir
     return { Requirements::gameDependency({ u"Oblivion"_s, u"Fallout 3"_s, u"New Vegas"_s, u"Skyrim"_s, u"Enderal"_s,
                                             u"Fallout 4"_s, u"Skyrim Special Edition"_s, u"Enderal Special Edition"_s,
                                             u"Skyrim VR"_s, u"Fallout 4 VR"_s,
-                                            u"Starfield"_s }) };
+                                            u"Starfield"_s, u"Oblivion Remastered"_s }) };
 }
 
 QString MO2Notes::author() const { return u"aglowinthefield"_s; }


### PR DESCRIPTION
Hi, as mentioned in issue #1 , MO2 already supports Oblivion Remastered on 2.5.3 dev and beta builds (available in their discord server). Is there anything else needed (or any other reason) for MO2 to be able to use your plugin with the game, or just this change?

Thanks again for this plugin! 😃
(Closed the first PR and opened a new one cause I noticed the game dependency list was in game release order)